### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ server.route({
 const Houdin = require('houdin');
 
 const options = { whitelist: ['image/png'] };
-const png = new Buffer('89504e47', 'hex');
+const png = Buffer.from('89504e47', 'hex');
 
 Houdin.validate({ file: png }, options, (err, value) => {
 
@@ -72,7 +72,7 @@ Houdin.validate({ file: png }, options, (err, value) => {
 const Houdin = require('houdin');
 
 const options = { whitelist: ['image/png'] };
-const gif = new Buffer('47494638', 'hex');
+const gif = Buffer.from('47494638', 'hex');
 
 Houdin.validate({ file: gif }, options, (err, value) => {
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   },
   "homepage": "https://github.com/ruiquelhas/houdin#readme",
   "devDependencies": {
-    "code": "3.x.x",
+    "code": "4.x.x",
     "coveralls": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x",
+    "hapi": "15.x.x",
+    "lab": "11.x.x",
     "multi-part": "1.x.x"
   },
   "dependencies": {
@@ -39,6 +39,6 @@
     "hoek": "4.x.x"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.5.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ lab.experiment('houdin', () => {
 
         const unknown = Path.join(Os.tmpdir(), 'unknown');
 
-        Fs.createWriteStream(unknown).end(new Buffer('0000', 'hex'));
+        Fs.createWriteStream(unknown).end(Buffer.from('0000', 'hex'));
 
         const form = new Form();
         form.append('file', Fs.createReadStream(unknown));
@@ -83,8 +83,8 @@ lab.experiment('houdin', () => {
         const png = Path.join(Os.tmpdir(), 'foo.png');
         const gif = Path.join(Os.tmpdir(), 'foo.gif');
 
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
-        Fs.createWriteStream(gif).end(new Buffer('47494638', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
+        Fs.createWriteStream(gif).end(Buffer.from('47494638', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(gif));
@@ -108,7 +108,7 @@ lab.experiment('houdin', () => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
 
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(png));


### PR DESCRIPTION
Update 3rd-party modules and supported node engine. Switch to the new `Buffer` API available since `v4.5.0`.
