### PR TITLE
Add support to handle undefined whitelists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ internals.validate = function (payload, options, next) {
         }
 
         const type = Magic(parameter);
-        const list = options.whitelist;
+        const list = options.whitelist || [];
 
         if (!type) {
             return next({ name: key, description: 'type is unknown' });

--- a/test/index.js
+++ b/test/index.js
@@ -15,15 +15,16 @@ const lab = exports.lab = Lab.script();
 
 lab.experiment('houdin', () => {
 
-    let server;
+    let goodServer;
+    let badServer;
     let unknown;
     let png;
     let gif;
 
     lab.before((done) => {
 
-        server = new Hapi.Server();
-        server.connection({
+        goodServer = new Hapi.Server();
+        goodServer.connection({
             routes: {
                 validate: {
                     options: {
@@ -33,34 +34,47 @@ lab.experiment('houdin', () => {
             }
         });
 
-        const baseConfig = {
-            handler: (request, reply) => reply(),
-            validate: {
-                payload: Houdin.validate
+        badServer = new Hapi.Server();
+        badServer.connection({
+            routes: {
+                validate: {
+                    options: { }
+                }
             }
-        };
+        });
 
-        server.route([{
-            config: baseConfig,
+        const baseConfig = {
+            config: {
+                handler: (request, reply) => reply(),
+                validate: {
+                    payload: Houdin.validate
+                }
+            },
             method: 'POST',
             path: '/data'
-        }, {
-            config: Object.assign({}, baseConfig, {
-                payload: {
-                    output: 'stream'
-                }
+        };
+
+        goodServer.route(baseConfig);
+
+        badServer.route([
+            baseConfig,
+            Object.assign({}, baseConfig, {
+                config: Object.assign({}, baseConfig.config, {
+                    payload: {
+                        output: 'stream'
+                    }
+                }),
+                path: '/stream'
             }),
-            method: 'POST',
-            path: '/stream'
-        }, {
-            config: Object.assign({}, baseConfig, {
-                payload: {
-                    output: 'file'
-                }
-            }),
-            method: 'POST',
-            path: '/file'
-        }]);
+            Object.assign({}, baseConfig, {
+                config: Object.assign({}, baseConfig.config, {
+                    payload: {
+                        output: 'file'
+                    }
+                }),
+                path: '/file'
+            })
+        ]);
 
         done();
     });
@@ -90,7 +104,7 @@ lab.experiment('houdin', () => {
         const form = new Form();
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
+        goodServer.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             done();
@@ -103,7 +117,7 @@ lab.experiment('houdin', () => {
         form.append('file', Fs.createReadStream(unknown));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
+        goodServer.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(400);
             Code.expect(response.result).to.include(['message', 'validation']);
@@ -123,7 +137,7 @@ lab.experiment('houdin', () => {
         form.append('file3', Fs.createReadStream(gif));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
+        goodServer.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(400);
             Code.expect(response.result).to.include(['message', 'validation']);
@@ -135,6 +149,23 @@ lab.experiment('houdin', () => {
         });
     });
 
+    lab.test('should return error if no whitelist is specified', (done) => {
+
+        const form = new Form();
+        form.append('file', Fs.createReadStream(png));
+
+        badServer.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
+
+            Code.expect(response.statusCode).to.equal(400);
+            Code.expect(response.result).to.include(['message', 'validation']);
+            Code.expect(response.result.message).to.equal('child \"file\" fails because [\"file\" type is not allowed]');
+            Code.expect(response.result.validation).to.include(['source', 'keys']);
+            Code.expect(response.result.validation.source).to.equal('payload');
+            Code.expect(response.result.validation.keys).to.include('file');
+            done();
+        });
+    });
+
     lab.test('should return control to the server if all files the payload are allowed', (done) => {
 
         const form = new Form();
@@ -142,7 +173,7 @@ lab.experiment('houdin', () => {
         form.append('file2', Fs.createReadStream(png));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
+        goodServer.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/data' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             done();
@@ -151,7 +182,7 @@ lab.experiment('houdin', () => {
 
     lab.test('should return control to the server if the payload is parsed as a temporary file', (done) => {
 
-        server.inject({ method: 'POST', payload: undefined, url: '/file' }, (response) => {
+        badServer.inject({ method: 'POST', payload: undefined, url: '/file' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             done();
@@ -160,7 +191,7 @@ lab.experiment('houdin', () => {
 
     lab.test('should return control to the server if the payload is parsed as a stream', (done) => {
 
-        server.inject({ method: 'POST', payload: undefined, url: '/stream' }, (response) => {
+        badServer.inject({ method: 'POST', payload: undefined, url: '/stream' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             done();


### PR DESCRIPTION
Currently, if no `whitelist` is provided, a server exception is thrown resulting in a bogus `HTTP 500` error. This is not clean, because a lot of unneeded implementation details get exposed in the stack trace. 

This patch introduces a change that forces the server to reject any kind of file type, since this corner-case is probably a mistake, and the best way to handle it is to signal that circumstance to the developer and at the same time, provide sane security defaults. This is, in fact, a breaking change, because instead of an `HTTP 500` error, the server will return a regular `HTTP 400` validation error.

