### PR TITLE
Update hapi minimum required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "code": "4.x.x",
     "coveralls": "3.x.x",
-    "hapi": "16.x.x",
+    "hapi": "16.1.x",
     "lab": "14.x.x",
     "multi-part": "2.x.x"
   },


### PR DESCRIPTION
https://nodesecurity.io/advisories/hapi_denial-of-service-via-malformed-accept-encoding-header