### PR TITLE
Fix hapi minimum required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "code": "4.x.x",
     "coveralls": "3.x.x",
-    "hapi": "16.1.x",
+    "hapi": "16.2.x",
     "lab": "14.x.x",
     "multi-part": "2.x.x"
   },


### PR DESCRIPTION
The change introduced by #32 does not cut it, at least from the perspective of dependency checkers.